### PR TITLE
update cardgrouplayout

### DIFF
--- a/app/components/molecules/CardGroupLayout/index.tsx
+++ b/app/components/molecules/CardGroupLayout/index.tsx
@@ -26,11 +26,11 @@ export const CardGroupLayout = (data: LayoutData) => {
       <Text className="title">{data.text}</Text>
       {data.url ? (
         <HyperLink className="text" href={data.url} color="yellow">
-          {typeof data.value === "string" ? data.value : data.value.toFixed(2)}
+          {typeof data.value === "string" ? data.value : data.value.toFixed(0)}
         </HyperLink>
       ) : (
         <Text className="text" color={data.color || undefined}>
-          {typeof data.value === "string" ? data.value : data.value.toFixed(2)}
+          {typeof data.value === "string" ? data.value : data.value.toFixed(0)}
         </Text>
       )}
     </Group>


### PR DESCRIPTION
updating tofixed to be not include decimal places
too many numbers should not have any decimals and it simply made those numbers more confusing rather than simplifying the occasional time when a number might have an excessive amount of decimals