### PR TITLE
update: separating tests to be more specific on when they run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy to server
+
+on: [push]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploying to web server
+        uses: garygrossgarten/github-action-ssh@release
+        with:
+          command: ${{ secrets.RUN }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
-name: Node.js CI/CD
+name: Test Runners
 
-on: [push] # tells github to run this on any push to the repository
+on:
+  pull_request:
+    types: [opened, edited, reopened]
 
 jobs:
   test: # names the job
@@ -28,18 +30,3 @@ jobs:
       - run: pnpm run build # builds your app
         env:
           CI: true # shows terminal output!
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: test # this job depends on "test" having finished
-    if: github.ref == 'refs/heads/main' # we tell Github to only execute this step if we're on our master branch (so we don't put unfinished branches in production)
-    steps:
-      - name: Deploying to web server
-        uses: garygrossgarten/github-action-ssh@release
-        with: # We set all our secrets here for the action, these won't be shown in the action logs
-          command: ${{ secrets.RUN }}
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          password: ${{ secrets.PASSWORD }}
-          port: ${{ secrets.PORT }}
-          


### PR DESCRIPTION
Splitting workflows into test runners and deploy runners

Since deploying is only possible once tests have run (which are required before PR's can be merged), then it should be safe to allow deploying when anything is pushed to master (which requires a PR to merge into).

So this is more efficient and will waste less time on test running when it is not really necessary